### PR TITLE
Return the number of blocks completely read when querying read completion

### DIFF
--- a/src/common/pico_sd_card/include/pico/sd_card.h
+++ b/src/common/pico_sd_card/include/pico/sd_card.h
@@ -40,7 +40,7 @@ int sd_init_1pin();
 int sd_readblocks_sync(uint32_t *buf, uint32_t block, uint block_count);
 int sd_readblocks_async(uint32_t *buf, uint32_t block, uint block_count);
 int sd_readblocks_scatter_async(uint32_t *control_words, uint32_t block, uint block_count);
-bool sd_scatter_read_complete(int *status);
+bool sd_scatter_read_complete(int *status, int *blocks_complete);
 int sd_writeblocks_async(const uint32_t *data, uint32_t sector_num, uint sector_count);
 bool sd_write_complete(int *status);
 int sd_read_sectors_1bit_crc_async(uint32_t *sector_buf, uint32_t sector, uint sector_count);

--- a/src/rp2_common/pico_sd_card/sd_card.c
+++ b/src/rp2_common/pico_sd_card/sd_card.c
@@ -705,7 +705,7 @@ int sd_readblocks_sync(uint32_t *buf, uint32_t block, uint block_count)
     if (!rc)
     {
 //        printf("waiting for finish\n");
-        while (!sd_scatter_read_complete(&rc))
+        while (!sd_scatter_read_complete(&rc, NULL))
         {
             tight_loop_contents();
         }
@@ -804,7 +804,7 @@ int sd_readblocks_scatter_async(uint32_t *control_words, uint32_t block, uint bl
 
 int check_crc_count;
 
-bool sd_scatter_read_complete(int *status) {
+bool sd_scatter_read_complete(int *status, int *blocks_complete) {
 //    printf("%d:%d %d:%d %d:%d %d\n", dma_busy(sd_chain_dma_channel), (uint)dma_hw->ch[sd_chain_dma_channel].transfer_count,
 //           dma_busy(sd_data_dma_channel), (uint)dma_hw->ch[sd_data_dma_channel].transfer_count,
 //           dma_busy(sd_pio_dma_channel), (uint)dma_hw->ch[sd_pio_dma_channel].transfer_count, (uint)pio->sm[SD_DAT_SM].addr);
@@ -827,6 +827,10 @@ bool sd_scatter_read_complete(int *status) {
             }
         }
         check_crc_count = 0;
+    }
+    else if (blocks_complete)
+    {
+        *blocks_complete = ((uint32_t*)dma_channel_hw_addr(sd_chain_dma_channel)->read_addr - ctrl_words) >> 2;
     }
     if (status) *status = s;
     return rc;


### PR DESCRIPTION
Especially when doing a longer async transfer, it can be useful to start reading it before it has finished.

This change allows the user to read the number of blocks already read by checking how far the chain DMA has got.

It's a breaking change, but I don't think there are many users yet, and you can just use NULL if you don't care.