### PR TITLE
Fixup rosc_set_div function

### DIFF
--- a/src/rp2_common/hardware_rosc/rosc.c
+++ b/src/rp2_common/hardware_rosc/rosc.c
@@ -30,8 +30,13 @@ uint rosc_find_freq(uint32_t low_mhz, uint32_t high_mhz) {
 }
 
 void rosc_set_div(uint32_t div) {
-    assert(div <= 31 && div >= 1);
-    rosc_write(&rosc_hw->div, ROSC_DIV_VALUE_PASS + div);
+    assert(div <= 31);
+    rosc_clear_bad_write();
+    assert(rosc_write_okay());
+    // don't use rosc_write here because setting a valid DIV is incorrectly flagged as a bad write
+    rosc_hw->div = ROSC_DIV_VALUE_PASS + div;
+    rosc_clear_bad_write();
+    assert(rosc_write_okay());
 }
 
 void rosc_set_freq(uint32_t code) {


### PR DESCRIPTION
A ROSC DIV of 0 is okay (and sets DIV = 32)
Writing ROSC DIV incorrectly sets BADWRITE, so avoid rosc_write and manually clear the BADWRITE bit