### PR TITLE
Fix channel status bit location in pico_audio_spdif

### DIFF
--- a/src/rp2_common/pico_audio_spdif/audio_spdif.c
+++ b/src/rp2_common/pico_audio_spdif/audio_spdif.c
@@ -101,10 +101,10 @@ static void init_spdif_buffer(audio_buffer_t *buffer) {
 //        p++;
 
         p->l = (i ? PREAMBLE_X : PREAMBLE_Z) | 0b10101010101010100000000;
-        p->h = 0x55000000u | (c_bit << 25u);
+        p->h = 0x55000000u | (c_bit << 29u);
         p++;
         p->l = PREAMBLE_Y | 0b10101010101010100000000;
-        p->h = 0x55000000u | (c_bit << 25u);
+        p->h = 0x55000000u | (c_bit << 29u);
         p++;
 
     }


### PR DESCRIPTION
An incorrect bitshift causes pico_audio_spdif to insert the S/PDIF channel status bitstream into the Validity (V) bit of each subframe, instead of in the Channel status (C) bit. 
This causes random subframes close to the beginning of a frame to be marked as invalid based on the value of `SPDIF_CONTROL_WORD`, which results in audible distortion as the S/PDIF receiver discards them.

This PR corrects the shift, leaving the V and U bits always set to 0.

I have verified that a WM8805 receiver correctly decodes the channel status data as 0x24 with this PR, and marks some subframes as invalid without it.