### PR TITLE
Make the FetchContent name be lower case

### DIFF
--- a/external/pico_extras_import.cmake
+++ b/external/pico_extras_import.cmake
@@ -26,14 +26,14 @@ if (NOT PICO_EXTRAS_PATH)
             get_filename_component(FETCHCONTENT_BASE_DIR "${PICO_EXTRAS_FETCH_FROM_GIT_PATH}" REALPATH BASE_DIR "${CMAKE_SOURCE_DIR}")
         endif ()
         FetchContent_Declare(
-                PICO_EXTRAS
+                pico_extras
                 GIT_REPOSITORY https://github.com/raspberrypi/pico-extras
                 GIT_TAG master
         )
-        if (NOT PICO_EXTRAS)
-            message("Downloading PICO EXTRAS")
-            FetchContent_Populate(PICO_EXTRAS)
-            set(PICO_EXTRAS_PATH ${PICO_EXTRAS_SOURCE_DIR})
+        if (NOT pico_extras)
+            message("Downloading Raspberry Pi Pico Extras")
+            FetchContent_Populate(pico_extras)
+            set(PICO_EXTRAS_PATH ${pico_extras_SOURCE_DIR})
         endif ()
         set(FETCHCONTENT_BASE_DIR ${FETCHCONTENT_BASE_DIR_SAVE})
     else ()


### PR DESCRIPTION
This brings the code in-line with what is done in the Pico SDK and
seems to be required in order for pico_extras_SOURCE_PATH to be set.

Fixes #24