### PR TITLE
Add iperf to lwip

### DIFF
--- a/src/rp2_common/lwip/CMakeLists.txt
+++ b/src/rp2_common/lwip/CMakeLists.txt
@@ -46,6 +46,7 @@ if (EXISTS ${LWIP_PATH}/${LWIP_TEST_PATH})
         ${LWIP_PATH}/src/netif/slipif.c
         ${LWIP_PATH}/src/apps/http/httpd.c
         ${LWIP_PATH}/src/apps/http/fs.c
+        ${LWIP_PATH}/src/apps/lwiperf/lwiperf.c
 
         ${CMAKE_CURRENT_LIST_DIR}/lwip_arch.c
     )


### PR DESCRIPTION
The iperf server is useful for testing performance. Currently it's not
in the list of apps added by the lwip interface library in pico-extras.