### PR TITLE
Claim the chaining DMA fragment channels if used

### DIFF
--- a/src/rp2_common/pico_scanvideo_dpi/scanvideo.c
+++ b/src/rp2_common/pico_scanvideo_dpi/scanvideo.c
@@ -1509,6 +1509,7 @@ bool scanvideo_setup_with_timing(const scanvideo_mode_t *mode, const scanvideo_t
                   1,
 #endif
                   false);
+    dma_channel_claim(PICO_SCANVIDEO_SCANLINE_DMA_CB_CHANNEL);
 #endif
 #if PICO_SCANVIDEO_PLANE_COUNT > 1
     channel_config = dma_channel_get_default_config(PICO_SCANVIDEO_SCANLINE_DMA_CHANNEL2);
@@ -1548,6 +1549,7 @@ bool scanvideo_setup_with_timing(const scanvideo_mode_t *mode, const scanvideo_t
                   1,
 #endif
                   false);
+    dma_channel_claim(PICO_SCANVIDEO_SCANLINE_DMA_CB_CHANNEL2);
 #endif
 #if PICO_SCANVIDEO_PLANE_COUNT > 2
 #if PICO_SCANVIDEO_PLANE3_FRAGMENT_DMA


### PR DESCRIPTION
The DMA fragment chaining channels used by scanvideo aren't claimed, so if another module starts claiming DMA channels you end up with a conflict.

This is a simple fix to claim the channels as they are configured.  Ideally scanvideo wouldn't use hardcoded channel numbers, but it isn't a big problem to make sure it is initialized first.