### PR TITLE
Add Support for Composite SYNC

### DIFF
--- a/src/common/pico_scanvideo/include/pico/scanvideo/scanvideo_base.h
+++ b/src/common/pico_scanvideo/include/pico/scanvideo/scanvideo_base.h
@@ -123,6 +123,12 @@ extern "C" {
 // most likely 24000000
 extern const uint32_t video_clock_freq;
 
+// Apply CSYNC flag to HSYNC polarity
+//  - Extend   : Extends HSYNC during VSYNC pulse period
+//  - Suppress : HSYNC inhibit during VSYNC period
+#define CSYNC_EXTEND 2
+#define CSYNC_SUPPRESS 4
+
 // todo pragma pack?
 typedef struct scanvideo_timing {
     uint32_t clock_freq;

--- a/src/rp2_common/pico_scanvideo_dbi/video.h
+++ b/src/rp2_common/pico_scanvideo_dbi/video.h
@@ -63,6 +63,12 @@ extern "C" {
 // most likely 24000000
 extern const uint32_t vga_clock_freq;
 
+// Apply CSYNC flag to HSYNC polarity
+//  - Extend   : Extends HSYNC during VSYNC pulse period
+//  - Suppress : HSYNC inhibit during VSYNC period
+#define CSYNC_EXTEND 2
+#define CSYNC_SUPPRESS 4
+
 // todo pragma pack?
 struct video_timing
 {


### PR DESCRIPTION
Many older arcade CRT monitors take CSYNC (combined VSYNC and HSYNC) rather than the HSYNC and VSYNC currently generated by the scanvideo library.  This enhancement allows a user to add a flag CSYNC_EXTEND or CSYNC_SUPPRESS to the h_sync_polarity to change this into a combined CSYNC.

CSYNC_SUPPRESS (compatible with old arcade games e.g. Galaxian) causes HSYNC to be suppressed during VSYNC, CSYNC_EXTEND effectively reverses the polarity and timing of HSYNC during VSYNC allowing monitors to detect VSYNC but not lose timing.
