### PR TITLE
Fix panic in scanvideo.c with recurring sys_clk

### DIFF
--- a/src/rp2_common/pico_scanvideo_dpi/scanvideo.c
+++ b/src/rp2_common/pico_scanvideo_dpi/scanvideo.c
@@ -1383,11 +1383,11 @@ bool scanvideo_setup_with_timing(const scanvideo_mode_t *mode, const scanvideo_t
     uint sys_clk = clock_get_hz(clk_sys);
     video_clock_down_times_2 = sys_clk / timing->clock_freq;
 #if PICO_SCANVIDEO_ENABLE_CLOCK_PIN
-    if (video_clock_down_times_2 * timing->clock_freq != sys_clk) {
+    if (timing->clock_freq != sys_clk / video_clock_down_times_2) {
         panic("System clock (%d) must be an integer multiple of 2 times the requested pixel clock (%d).", sys_clk, timing->clock_freq);
     }
 #else
-    if (video_clock_down_times_2 * timing->clock_freq != sys_clk) {
+    if (timing->clock_freq != sys_clk / video_clock_down_times_2) {
         panic("System clock (%d) must be an integer multiple of the requested pixel clock (%d).", sys_clk, timing->clock_freq);
     }
 #endif


### PR DESCRIPTION
When the system clock is set to a value which is a recurring number, scanvideo.c will always panic even when the system clock is effectively an integer multiple of 2 times the desired pixel clock.

This is due to the system clock and the pixel clock being truncated to different levels of precision. e.g:

I was experimenting with custom scanvideo timings and wanted an output using a 14.318181Mhz pixel clock (or a close approximation of this NTSC frequency) and vcocalc.py gave the following solution for an 8x system clock:

Requested: 114.545448 MHz
Achieved: 114.66666666666667 MHz
FBDIV: 86 (VCO = 1032 MHz)
PD1: 3
PD2: 3

I set the system clock with the above values and specified the pixel clock frequency as 14333333 in my scanvideo timing struct (timing->clock_freq) and that led to the panic:
System clock (114666666) must be an integer multiple of 2 times the requested pixel clock (14333333).

This is due to the way the comparison is made by multiplying the pixel clock by the scale factor and comparing with the system clock which will fail as 14333333*8 = 114666664 not 114666666.

The fix is to divide the system clock by the scale factor and compare with the pixel clock and this will succeed as both sides have been truncated to the same level of precision. (114666666 / 8 = 14333333)
