### PR TITLE
Support claiming unused SM/channels for audio

### DIFF
--- a/src/rp2_common/pico_audio_spdif/audio_spdif.c
+++ b/src/rp2_common/pico_audio_spdif/audio_spdif.c
@@ -128,8 +128,14 @@ const audio_format_t *audio_spdif_setup(const audio_format_t *intended_audio_for
     uint func = GPIO_FUNC_PIOx;
     gpio_set_function(config->pin, func);
 
-    uint8_t sm = shared_state.pio_sm = config->pio_sm;
-    pio_sm_claim(audio_pio, sm);
+    uint8_t sm = config->pio_sm;
+    if (sm == 0xFF) {
+        sm = pio_claim_unused_sm(audio_pio, true);
+    } else {
+        pio_sm_claim(audio_pio, sm);
+    }
+
+    shared_state.pio_sm = sm;
 
     uint offset = pio_add_program(audio_pio, &audio_spdif_program);
 
@@ -144,8 +150,13 @@ const audio_format_t *audio_spdif_setup(const audio_format_t *intended_audio_for
     }
 
     __mem_fence_release();
+
     uint8_t dma_channel = config->dma_channel;
-    dma_channel_claim(dma_channel);
+    if(dma_channel == 0xFF) {
+        dma_channel = dma_claim_unused_channel(true);
+    } else {
+        dma_channel_claim(dma_channel);
+    }
 
     shared_state.dma_channel = dma_channel;
 


### PR DESCRIPTION
Uses a `dma_channel`/`pio_sm` of 0xFF to mean "claim unused". (Considered changing the configs to signed and/or adding some defines, but thought I should try the smallest change first...)


This change was motivated by finding that I'd written this in a project:
```c
uint8_t dma_channel = dma_claim_unused_channel(true);
uint8_t pio_sm = pio_claim_unused_sm(audio_pio, true);

dma_channel_unclaim(dma_channel);
pio_sm_unclaim(audio_pio, pio_sm);

struct audio_i2s_config config = {
  .data_pin = PICO_AUDIO_I2S_DATA_PIN,
  .clock_pin_base = PICO_AUDIO_I2S_CLOCK_PIN_BASE,
  .dma_channel = dma_channel,
  .pio_sm = pio_sm,
};
```

Ugh.