### PR TITLE
Use joined FIFO mode in audio_i2s.pio

### DIFF
--- a/src/rp2_common/pico_audio_i2s/audio_i2s.pio
+++ b/src/rp2_common/pico_audio_i2s/audio_i2s.pio
@@ -50,6 +50,7 @@ static inline void audio_i2s_program_init(PIO pio, uint sm, uint offset, uint da
     sm_config_set_out_pins(&sm_config, data_pin, 1);
     sm_config_set_sideset_pins(&sm_config, clock_pin_base);
     sm_config_set_out_shift(&sm_config, false, true, 32);
+    sm_config_set_fifo_join(&sm_config, PIO_FIFO_JOIN_TX);
 
     pio_sm_init(pio, sm, offset, &sm_config);
 


### PR DESCRIPTION
As state machine is output only it is possible to use joined FIFO mode. It allows more jitter(reaction time to DMA complete event when using only one DMA channel) on producer side of FIFO.