### PR TITLE
Delete .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,5 +1,0 @@
-[submodule "lwip"]
-	path = lib/lwip
-	url = https://git.savannah.nongnu.org/git/lwip.git
-[submodule "lib/lwip"]
-	url = git://git.savannah.nongnu.org/lwip.git


### PR DESCRIPTION
The lwip submodule was removed in https://github.com/raspberrypi/pico-extras/commit/5e594d417d10adc341eb9a884810022f2f6ca5cc so there's now no need for the `.gitmodules` file to exist.