### PR TITLE
Fix warning in sd_test.c

### DIFF
--- a/test/sd_test/sd_test.c
+++ b/test/sd_test/sd_test.c
@@ -10,6 +10,7 @@
 
 #include "pico/stdlib.h"
 #include "pico/sd_card.h"
+#include "hardware/clocks.h"
 
 static uint8_t sector_data[1024];
 


### PR DESCRIPTION
Fix `warning: implicit declaration of function 'set_sys_clock_48mhz'` that you get when compiling with SDK 2.0.0