### PR TITLE
Add 640x400 @ 70Hz mode

### DIFF
--- a/src/common/pico_scanvideo/include/pico/scanvideo/scanvideo_base.h
+++ b/src/common/pico_scanvideo/include/pico/scanvideo/scanvideo_base.h
@@ -279,6 +279,10 @@ extern const scanvideo_mode_t vga_mode_160x120_60; // 3d monster maze anyone :-)
 extern const scanvideo_mode_t vga_mode_213x160_60;
 extern const scanvideo_mode_t vga_mode_320x240_60;
 extern const scanvideo_mode_t vga_mode_640x480_60;
+
+extern const scanvideo_mode_t vga_mode_320x200_70;
+extern const scanvideo_mode_t vga_mode_640x400_70;
+
 extern const scanvideo_mode_t vga_mode_800x600_54;
 extern const scanvideo_mode_t vga_mode_800x600_60;
 extern const scanvideo_mode_t vga_mode_1024x768_63;

--- a/src/common/pico_scanvideo/vga_modes.c
+++ b/src/common/pico_scanvideo/vga_modes.c
@@ -425,13 +425,13 @@ const scanvideo_timing_t vga_timing_640x480_60_default =
                 .v_active = 480,
 
                 .h_front_porch = 16,
-                .h_pulse = 64,
+                .h_pulse = 64,          // spec says 96 ?
                 .h_total = 800,
                 .h_sync_polarity = 1,
 
-                .v_front_porch = 1,
+                .v_front_porch = 1,     // spec says 10 ?
                 .v_pulse = 2,
-                .v_total = 523,
+                .v_total = 523,         // spec says 525 ?
                 .v_sync_polarity = 1,
 
                 .enable_clock = 0,
@@ -477,6 +477,49 @@ const scanvideo_mode_t vga_mode_640x480_60 =
                 .pio_program = &video_24mhz_composable,
                 .width = 640,
                 .height = 480,
+                .xscale = 1,
+                .yscale = 1,
+        };
+
+const scanvideo_timing_t vga_timing_640x400_70_default =
+        {
+                .clock_freq = 25000000, // 25.175MHz
+
+                .h_active = 640,
+                .v_active = 400,
+
+                .h_front_porch = 16,
+                .h_pulse = 96,
+                .h_total = 800,
+                .h_sync_polarity = 1,
+
+                .v_front_porch = 3,     // vs 12
+                .v_pulse = 2,
+                .v_total = 446,         // 449 * 800 * 70 / 25.175M 0.9987  vs 446 * 800 * 70 / 25 000 000 = .99904
+                .v_sync_polarity = 0,   // note opposite polarity
+
+                .enable_clock = 0,
+                .clock_polarity = 0,
+
+                .enable_den = 0
+        };
+
+const scanvideo_mode_t vga_mode_320x200_70 =
+        {
+                .default_timing = &vga_timing_640x400_70_default,
+                .pio_program = &video_24mhz_composable,
+                .width = 320,
+                .height = 200,
+                .xscale = 2,
+                .yscale = 2,
+        };
+
+const scanvideo_mode_t vga_mode_640x400_70 =
+        {
+                .default_timing = &vga_timing_640x400_70_default,
+                .pio_program = &video_24mhz_composable,
+                .width = 640,
+                .height = 400,
                 .xscale = 1,
                 .yscale = 1,
         };


### PR DESCRIPTION
It'd be great if someone could document how the timing parameters are set up.  

I added the 640x400 mode per http://www.tinyvga.com/vga-timing/640x400@70Hz since that aspect ratio is useful for me.

It seems to work but I'm uncertain about how to choose the different parameters since the 640x480 mode seems slightly different from the spec at http://www.tinyvga.com/vga-timing/640x480@60Hz and elsewhere.

I'm also curious why the PICO_SCANVIDEO_48MHZ modes are all ifdef'd out by default.  I tried to add them back with `add_definitions( -DPICO_SCANVIDEO_48MHZ=1 )` but they didn't seem to work directly even tho the clock seems slower than default 640x480 mode.  

