### PR TITLE
Include hardware/timer.h

### DIFF
--- a/src/rp2_common/pico_sleep/include/pico/sleep.h
+++ b/src/rp2_common/pico_sleep/include/pico/sleep.h
@@ -9,7 +9,7 @@
 
 #include "pico.h"
 #include "hardware/rosc.h"
-
+#include "hardware/timer.h"
 #include "pico/aon_timer.h"
 
 #ifdef __cplusplus


### PR DESCRIPTION
If you include sleep.h first you get a compile error as hardware_alarm_callback_t is not defined. Fix this by including the appropriate header.

Fixes #89