### PR TITLE
Include hardware/timer.h

### DIFF
--- a/src/rp2_common/pico_sleep/include/pico/sleep.h
+++ b/src/rp2_common/pico_sleep/include/pico/sleep.h
@@ -9,6 +9,7 @@
 
 #include "pico.h"
 #include "hardware/rosc.h"
+#include "hardware/timer.h"
 
 #include "pico/aon_timer.h"
 


### PR DESCRIPTION
Declaration for hardware_alarm_callback_t was missing.