### PR TITLE
Throw error when not using software spinlocks on RP2350

### DIFF
--- a/src/common/pico_audio/include/pico/audio.h
+++ b/src/common/pico_audio/include/pico/audio.h
@@ -25,7 +25,7 @@ extern "C" {
 // PICO_CONFIG: SPINLOCK_ID_AUDIO_FREE_LIST_LOCK, Spinlock number for the audio free list, min=0, max=31, default=6, group=audio
 #ifndef SPINLOCK_ID_AUDIO_FREE_LIST_LOCK
 #if PICO_RP2350 && !PICO_USE_SW_SPIN_LOCKS
-#error "When not using software spin locks on RP2350, you must explicitly define the pico-extras spinlock IDs, accounting for Errata E2 and the SDK spin lock IDs"
+#error "When not using software spin locks on RP2350, you must explicitly define SPINLOCK_ID_AUDIO_FREE_LIST_LOCK, taking Errata RP2350-E2 and the SDK spin lock IDs into account"
 #else
 #define SPINLOCK_ID_AUDIO_FREE_LIST_LOCK 6
 #endif
@@ -34,7 +34,7 @@ extern "C" {
 // PICO_CONFIG: SPINLOCK_ID_AUDIO_PREPARED_LISTS_LOCK, Spinlock number for the audio prepared list, min=0, max=31, default=7, group=audio
 #ifndef SPINLOCK_ID_AUDIO_PREPARED_LISTS_LOCK
 #if PICO_RP2350 && !PICO_USE_SW_SPIN_LOCKS
-#error "When not using software spin locks on RP2350, you must explicitly define the pico-extras spinlock IDs, accounting for Errata E2 and the SDK spin lock IDs"
+#error "When not using software spin locks on RP2350, you must explicitly define SPINLOCK_ID_AUDIO_PREPARED_LISTS_LOCK, taking Errata RP2350-E2 and the SDK spin lock IDs into account"
 #else
 #define SPINLOCK_ID_AUDIO_PREPARED_LISTS_LOCK 7
 #endif

--- a/src/common/pico_audio/include/pico/audio.h
+++ b/src/common/pico_audio/include/pico/audio.h
@@ -25,7 +25,7 @@ extern "C" {
 // PICO_CONFIG: SPINLOCK_ID_AUDIO_FREE_LIST_LOCK, Spinlock number for the audio free list, min=0, max=31, default=6, group=audio
 #ifndef SPINLOCK_ID_AUDIO_FREE_LIST_LOCK
 #if PICO_RP2350 && !PICO_USE_SW_SPIN_LOCKS
-#error "When not using software spin locks on RP2350, you must define SPINLOCK_ID_AUDIO_FREE_LIST_LOCK, accounting for Errata E2 and the SDK spin lock IDs"
+#error "When not using software spin locks on RP2350, you must explicitly define the pico-extras spinlock IDs, accounting for Errata E2 and the SDK spin lock IDs"
 #else
 #define SPINLOCK_ID_AUDIO_FREE_LIST_LOCK 6
 #endif
@@ -34,7 +34,7 @@ extern "C" {
 // PICO_CONFIG: SPINLOCK_ID_AUDIO_PREPARED_LISTS_LOCK, Spinlock number for the audio prepared list, min=0, max=31, default=7, group=audio
 #ifndef SPINLOCK_ID_AUDIO_PREPARED_LISTS_LOCK
 #if PICO_RP2350 && !PICO_USE_SW_SPIN_LOCKS
-#error "When not using software spin locks on RP2350, you must define SPINLOCK_ID_AUDIO_PREPARED_LISTS_LOCK, accounting for Errata E2 and the SDK spin lock IDs"
+#error "When not using software spin locks on RP2350, you must explicitly define the pico-extras spinlock IDs, accounting for Errata E2 and the SDK spin lock IDs"
 #else
 #define SPINLOCK_ID_AUDIO_PREPARED_LISTS_LOCK 7
 #endif

--- a/src/common/pico_audio/include/pico/audio.h
+++ b/src/common/pico_audio/include/pico/audio.h
@@ -24,12 +24,20 @@ extern "C" {
 
 // PICO_CONFIG: SPINLOCK_ID_AUDIO_FREE_LIST_LOCK, Spinlock number for the audio free list, min=0, max=31, default=6, group=audio
 #ifndef SPINLOCK_ID_AUDIO_FREE_LIST_LOCK
+#if PICO_RP2350 && !PICO_USE_SW_SPIN_LOCKS
+#error "When not using software spin locks on RP2350, you must define SPINLOCK_ID_AUDIO_FREE_LIST_LOCK, accounting for Errata E2 and the SDK spin lock IDs"
+#else
 #define SPINLOCK_ID_AUDIO_FREE_LIST_LOCK 6
+#endif
 #endif
 
 // PICO_CONFIG: SPINLOCK_ID_AUDIO_PREPARED_LISTS_LOCK, Spinlock number for the audio prepared list, min=0, max=31, default=7, group=audio
 #ifndef SPINLOCK_ID_AUDIO_PREPARED_LISTS_LOCK
+#if PICO_RP2350 && !PICO_USE_SW_SPIN_LOCKS
+#error "When not using software spin locks on RP2350, you must define SPINLOCK_ID_AUDIO_PREPARED_LISTS_LOCK, accounting for Errata E2 and the SDK spin lock IDs"
+#else
 #define SPINLOCK_ID_AUDIO_PREPARED_LISTS_LOCK 7
+#endif
 #endif
 
 // PICO_CONFIG: PICO_AUDIO_NOOP, Enable/disable audio by forcing NOOPS, type=bool, default=0, group=audio

--- a/src/common/pico_scanvideo/include/pico/scanvideo/scanvideo_base.h
+++ b/src/common/pico_scanvideo/include/pico/scanvideo/scanvideo_base.h
@@ -320,7 +320,7 @@ extern void scanvideo_default_configure_pio(pio_hw_t *pio, uint sm, uint offset,
 
 #ifndef PICO_SPINLOCK_ID_VIDEO_SCANLINE_LOCK
 #if PICO_RP2350 && !PICO_USE_SW_SPIN_LOCKS
-#error "When not using software spin locks on RP2350, you must explicitly define the pico-extras spinlock IDs, accounting for Errata E2 and the SDK spin lock IDs"
+#error "When not using software spin locks on RP2350, you must explicitly define PICO_SPINLOCK_ID_VIDEO_SCANLINE_LOCK, taking Errata RP2350-E2 and the SDK spin lock IDs into account"
 #else
 #define PICO_SPINLOCK_ID_VIDEO_SCANLINE_LOCK 2
 #endif
@@ -328,7 +328,7 @@ extern void scanvideo_default_configure_pio(pio_hw_t *pio, uint sm, uint offset,
 
 #ifndef PICO_SPINLOCK_ID_VIDEO_FREE_LIST_LOCK
 #if PICO_RP2350 && !PICO_USE_SW_SPIN_LOCKS
-#error "When not using software spin locks on RP2350, you must explicitly define the pico-extras spinlock IDs, accounting for Errata E2 and the SDK spin lock IDs"
+#error "When not using software spin locks on RP2350, you must explicitly define PICO_SPINLOCK_ID_VIDEO_FREE_LIST_LOCK, taking Errata RP2350-E2 and the SDK spin lock IDs into account"
 #else
 #define PICO_SPINLOCK_ID_VIDEO_FREE_LIST_LOCK 3
 #endif
@@ -336,7 +336,7 @@ extern void scanvideo_default_configure_pio(pio_hw_t *pio, uint sm, uint offset,
 
 #ifndef PICO_SPINLOCK_ID_VIDEO_DMA_LOCK
 #if PICO_RP2350 && !PICO_USE_SW_SPIN_LOCKS
-#error "When not using software spin locks on RP2350, you must explicitly define the pico-extras spinlock IDs, accounting for Errata E2 and the SDK spin lock IDs"
+#error "When not using software spin locks on RP2350, you must explicitly define PICO_SPINLOCK_ID_VIDEO_DMA_LOCK, taking Errata RP2350-E2 and the SDK spin lock IDs into account"
 #else
 #define PICO_SPINLOCK_ID_VIDEO_DMA_LOCK 4
 #endif
@@ -344,7 +344,7 @@ extern void scanvideo_default_configure_pio(pio_hw_t *pio, uint sm, uint offset,
 
 #ifndef PICO_SPINLOCK_ID_VIDEO_IN_USE_LOCK
 #if PICO_RP2350 && !PICO_USE_SW_SPIN_LOCKS
-#error "When not using software spin locks on RP2350, you must explicitly define the pico-extras spinlock IDs, accounting for Errata E2 and the SDK spin lock IDs"
+#error "When not using software spin locks on RP2350, you must explicitly define PICO_SPINLOCK_ID_VIDEO_IN_USE_LOCK, taking Errata RP2350-E2 and the SDK spin lock IDs into account"
 #else
 #define PICO_SPINLOCK_ID_VIDEO_IN_USE_LOCK 5
 #endif

--- a/src/common/pico_scanvideo/include/pico/scanvideo/scanvideo_base.h
+++ b/src/common/pico_scanvideo/include/pico/scanvideo/scanvideo_base.h
@@ -319,19 +319,35 @@ extern void scanvideo_default_configure_pio(pio_hw_t *pio, uint sm, uint offset,
 #endif
 
 #ifndef PICO_SPINLOCK_ID_VIDEO_SCANLINE_LOCK
+#if PICO_RP2350 && !PICO_USE_SW_SPIN_LOCKS
+#error "When not using software spin locks on RP2350, you must explicitly define the pico-extras spinlock IDs, accounting for Errata E2 and the SDK spin lock IDs"
+#else
 #define PICO_SPINLOCK_ID_VIDEO_SCANLINE_LOCK 2
+#endif
 #endif
 
 #ifndef PICO_SPINLOCK_ID_VIDEO_FREE_LIST_LOCK
+#if PICO_RP2350 && !PICO_USE_SW_SPIN_LOCKS
+#error "When not using software spin locks on RP2350, you must explicitly define the pico-extras spinlock IDs, accounting for Errata E2 and the SDK spin lock IDs"
+#else
 #define PICO_SPINLOCK_ID_VIDEO_FREE_LIST_LOCK 3
+#endif
 #endif
 
 #ifndef PICO_SPINLOCK_ID_VIDEO_DMA_LOCK
+#if PICO_RP2350 && !PICO_USE_SW_SPIN_LOCKS
+#error "When not using software spin locks on RP2350, you must explicitly define the pico-extras spinlock IDs, accounting for Errata E2 and the SDK spin lock IDs"
+#else
 #define PICO_SPINLOCK_ID_VIDEO_DMA_LOCK 4
+#endif
 #endif
 
 #ifndef PICO_SPINLOCK_ID_VIDEO_IN_USE_LOCK
+#if PICO_RP2350 && !PICO_USE_SW_SPIN_LOCKS
+#error "When not using software spin locks on RP2350, you must explicitly define the pico-extras spinlock IDs, accounting for Errata E2 and the SDK spin lock IDs"
+#else
 #define PICO_SPINLOCK_ID_VIDEO_IN_USE_LOCK 5
+#endif
 #endif
 
 // note this is not necessarily an absolute gpio pin mask, it is still shifted by PICO_SCANVIDEO_COLOR_PIN_BASE


### PR DESCRIPTION
You must manually define the spinlock IDs when not using software spin locks on RP2350, to avoid errata E2

Links with https://github.com/raspberrypi/pico-sdk/pull/2645