### PR TITLE
Rename hardware_rosc to hardware_rosc_extra

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ See [pico-playground](https://github.com/raspberrypi/pico-playground) for builda
 
 Library|Description 
 ---|---
-[hardware_rosc](src/rp2_common/hardware_rosc)| API for the ring oscillator
+[hardware_rosc_extra](src/rp2_common/hardware_rosc_extra)| Extra API functions for the ring oscillator
 `lwip`| Deprecated as of SDK 1.5.0; use `pico_lwip` and `pico_lwip_arch` from the SDK instead. 
 [pico_audio](src/common/pico_audio)|Audio output support; this is highly functional, but the API is subject to change 
 &nbsp;&nbsp;&nbsp;[pico_audio_i2s](src/rp2_common/pico_audio_i2s)|Audio output via I2S on 3 GPIOs using PIO. Arbitrary frequency

--- a/src/rp2_common/CMakeLists.txt
+++ b/src/rp2_common/CMakeLists.txt
@@ -1,5 +1,5 @@
 # This CMakeLists.txt intended to be included from other projectgs
-pico_add_subdirectory(hardware_rosc)
+pico_add_subdirectory(hardware_rosc_extra)
 pico_add_subdirectory(pico_sleep)
 pico_add_subdirectory(pico_audio_i2s)
 pico_add_subdirectory(pico_audio_pwm)

--- a/src/rp2_common/hardware_rosc/CMakeLists.txt
+++ b/src/rp2_common/hardware_rosc/CMakeLists.txt
@@ -1,1 +1,0 @@
-pico_simple_hardware_target(rosc)

--- a/src/rp2_common/hardware_rosc_extra/CMakeLists.txt
+++ b/src/rp2_common/hardware_rosc_extra/CMakeLists.txt
@@ -1,0 +1,4 @@
+pico_simple_hardware_target(rosc_extra)
+
+pico_mirrored_target_link_libraries(hardware_rosc_extra INTERFACE
+        hardware_rosc)

--- a/src/rp2_common/hardware_rosc_extra/include/hardware/rosc_extra.h
+++ b/src/rp2_common/hardware_rosc_extra/include/hardware/rosc_extra.h
@@ -4,20 +4,21 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#ifndef _HARDWARE_ROSC_H_
-#define _HARDWARE_ROSC_H_
+#ifndef _HARDWARE_ROSC_EXTRA_H_
+#define _HARDWARE_ROSC_EXTRA_H_
 
 #include "pico.h"
+#include "hardware/rosc.h"
 #include "hardware/structs/rosc.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-/** \file rosc.h
+/** \file rosc_extra.h
  *  \defgroup hardware_rosc hardware_rosc
  *
- * Ring Oscillator (ROSC) API
+ * Ring Oscillator (ROSC) API Extras
  *
  * A Ring Oscillator is an on-chip oscillator that requires no external crystal. Instead, the output is generated from a series of
  * inverters that are chained together to create a feedback loop. RP2040 boots from the ring oscillator initially, meaning the
@@ -43,23 +44,6 @@ void rosc_set_freq(uint32_t code);
  */
 void rosc_set_range(uint range);
 
-/*! \brief  Disable the Ring Oscillator
- *  \ingroup hardware_rosc
- *
- */
-void rosc_disable(void);
-
-/*! \brief  Put Ring Oscillator in to dormant mode.
- *  \ingroup hardware_rosc
- *
- * The ROSC supports a dormant mode,which stops oscillation until woken up up by an asynchronous interrupt.
- * This can either come from the RTC, being clocked by an external clock, or a GPIO pin going high or low.
- * If no IRQ is configured before going into dormant mode the ROSC will never restart.
- *
- * PLLs should be stopped before selecting dormant mode.
- */
-void rosc_set_dormant(void);
-
 // FIXME: Add doxygen
 
 uint32_t next_rosc_code(uint32_t code);
@@ -67,23 +51,6 @@ uint32_t next_rosc_code(uint32_t code);
 uint rosc_find_freq(uint32_t low_mhz, uint32_t high_mhz);
 
 void rosc_set_div(uint32_t div);
-
-inline static void rosc_clear_bad_write(void) {
-    hw_clear_bits(&rosc_hw->status, ROSC_STATUS_BADWRITE_BITS);
-}
-
-inline static bool rosc_write_okay(void) {
-    return !(rosc_hw->status & ROSC_STATUS_BADWRITE_BITS);
-}
-
-inline static void rosc_write(io_rw_32 *addr, uint32_t value) {
-    rosc_clear_bad_write();
-    assert(rosc_write_okay());
-    *addr = value;
-    assert(rosc_write_okay());
-};
-
-void rosc_enable(void);
 
 #ifdef __cplusplus
 }

--- a/src/rp2_common/hardware_rosc_extra/rosc_extra.c
+++ b/src/rp2_common/hardware_rosc_extra/rosc_extra.c
@@ -8,7 +8,7 @@
 
 // For MHZ definitions etc
 #include "hardware/clocks.h"
-#include "hardware/rosc.h"
+#include "hardware/rosc_extra.h"
 
 // Given a ROSC delay stage code, return the next-numerically-higher code.
 // Top result bit is set when called on maximum ROSC code.
@@ -42,28 +42,4 @@ void rosc_set_freq(uint32_t code) {
 void rosc_set_range(uint range) {
     // Range should use enumvals from the headers and thus have the password correct
     rosc_write(&rosc_hw->ctrl, (ROSC_CTRL_ENABLE_VALUE_ENABLE << ROSC_CTRL_ENABLE_LSB) | range);
-}
-
-void rosc_disable(void) {
-    uint32_t tmp = rosc_hw->ctrl;
-    tmp &= (~ROSC_CTRL_ENABLE_BITS);
-    tmp |= (ROSC_CTRL_ENABLE_VALUE_DISABLE << ROSC_CTRL_ENABLE_LSB);
-    rosc_write(&rosc_hw->ctrl, tmp);
-    // Wait for stable to go away
-    while(rosc_hw->status & ROSC_STATUS_STABLE_BITS);
-}
-
-void rosc_set_dormant(void) {
-    // WARNING: This stops the rosc until woken up by an irq
-    rosc_write(&rosc_hw->dormant, ROSC_DORMANT_VALUE_DORMANT);
-    // Wait for it to become stable once woken up
-    while(!(rosc_hw->status & ROSC_STATUS_STABLE_BITS));
-}
-
-void rosc_enable(void) {
-    //Re-enable the rosc
-    rosc_write(&rosc_hw->ctrl, ROSC_CTRL_ENABLE_BITS);
-
-    //Wait for it to become stable once restarted
-    while (!(rosc_hw->status & ROSC_STATUS_STABLE_BITS));
 }


### PR DESCRIPTION
hardware_rosc is now an SDK library, but there are still some functions left here that aren't implementd in the SDK

Having both libraries with the same name will not work, so renaming this one to hardware_rosc_extra